### PR TITLE
CLI App implements log sink interface

### DIFF
--- a/cli/app/logger/logger.go
+++ b/cli/app/logger/logger.go
@@ -1,0 +1,53 @@
+// Package logger for sending log events to the application.
+package logger
+
+import (
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/skpr/compass/cli/app/types"
+)
+
+// Logger for sending events into the CLI application.
+type Logger struct {
+	program *tea.Program
+}
+
+// New logger for sending events into the CLI application.
+func New(program *tea.Program) (*Logger, error) {
+	if program == nil {
+		return nil, fmt.Errorf("program not provided")
+	}
+
+	return &Logger{
+		program: program,
+	}, nil
+}
+
+// Info message being logged to the application.
+func (l *Logger) Info(_ string, _ ...any) {
+	// We don't log info events.
+}
+
+// Debug message being logged to the application.
+func (l *Logger) Debug(_ string, _ ...any) {
+	// We don't log debug events.
+}
+
+// Error message being logged to the application.
+func (l *Logger) Error(msg string, _ ...any) {
+	l.send(msg, "error")
+}
+
+// Send log events to the CLI application.
+func (l *Logger) send(msg, msgType string) {
+	log := types.Log{
+		Time:    time.Now(),
+		Type:    msgType,
+		Message: msg,
+	}
+
+	l.program.Send(log)
+}

--- a/cli/app/types/log.go
+++ b/cli/app/types/log.go
@@ -8,9 +8,9 @@ import (
 
 // Log event which occurred during execution.
 type Log struct {
-	Time      time.Time
-	Component string
-	Message   string
+	Time    time.Time
+	Type    string
+	Message string
 }
 
 // Title of the log message.
@@ -20,7 +20,7 @@ func (l Log) Title() string {
 
 // Description of the log message.
 func (l Log) Description() string {
-	return fmt.Sprintf("time=%s, component=%s", l.Time.Local().Format(time.RFC1123), l.Component)
+	return fmt.Sprintf("type=%s time=%s", l.Type, l.Time.Local().Format(time.RFC1123))
 }
 
 // FilterValue for searching.

--- a/cli/main.go
+++ b/cli/main.go
@@ -4,8 +4,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"regexp"
 	"strings"
 
@@ -17,6 +15,7 @@ import (
 
 	"github.com/skpr/compass/cli/app"
 	"github.com/skpr/compass/cli/app/color"
+	applogger "github.com/skpr/compass/cli/app/logger"
 	"github.com/skpr/compass/cli/sink"
 	"github.com/skpr/compass/collector"
 	"github.com/skpr/compass/collector/extension/discovery"
@@ -50,16 +49,17 @@ func main() {
 		Long:    cmdLong,
 		Example: cmdExample,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-				Level: slog.LevelError,
-			}))
-
-			path, err := discovery.GetPathFromProcess(logger, o.ProcessName, o.ExtensionPath)
+			path, err := discovery.GetPathFromProcess(o.ProcessName, o.ExtensionPath)
 			if err != nil {
 				return err
 			}
 
 			p := tea.NewProgram(app.NewModel(path), tea.WithAltScreen())
+
+			logger, err := applogger.New(p)
+			if err != nil {
+				return fmt.Errorf("failed to setup logger: %w", err)
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -39,7 +39,7 @@ type RunOptions struct {
 }
 
 // Run the collector.
-func Run(ctx context.Context, logger *slog.Logger, plugin sink.Interface, options RunOptions) error {
+func Run(ctx context.Context, logger Logger, plugin sink.Interface, options RunOptions) error {
 	logger.Info("Loading probes")
 
 	// Allow the current process to lock memory for eBPF resources.

--- a/collector/extension/discovery/discovery.go
+++ b/collector/extension/discovery/discovery.go
@@ -3,7 +3,6 @@ package discovery
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/cenkalti/backoff/v4"
@@ -11,12 +10,10 @@ import (
 )
 
 // GetPathFromProcess will wait and return the path to the extension for a process.
-func GetPathFromProcess(logger *slog.Logger, processName, extensionPath string) (string, error) {
+func GetPathFromProcess(processName, extensionPath string) (string, error) {
 	ticker := backoff.NewTicker(backoff.NewExponentialBackOff())
 
 	for range ticker.C {
-		logger.Info("Polling for list of processes")
-
 		pid, ok, err := findParentProcess(processName)
 		if err != nil {
 			return "", fmt.Errorf("failed to find parent process from list: %w", err)

--- a/collector/logger.go
+++ b/collector/logger.go
@@ -1,0 +1,8 @@
+package collector
+
+// Logger for emitting collector events.
+type Logger interface {
+	Info(msg string, args ...any)
+	Debug(msg string, args ...any)
+	Error(msg string, args ...any)
+}

--- a/collector/manager.go
+++ b/collector/manager.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -24,7 +23,7 @@ const (
 // Manager for handling events.
 type Manager struct {
 	// Logger for debugging.
-	logger *slog.Logger
+	logger Logger
 	// Consider an interface for the storage.
 	storage *cache.Cache
 	// Plugin for sending completed requests to.
@@ -39,7 +38,7 @@ type Options struct {
 }
 
 // NewManager creates a new manager.
-func NewManager(logger *slog.Logger, plugin sink.Interface, options Options) (*Manager, error) {
+func NewManager(logger Logger, plugin sink.Interface, options Options) (*Manager, error) {
 	client := &Manager{
 		logger:  logger,
 		storage: cache.New(options.Expire, options.Expire),

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -76,7 +76,7 @@ func main() {
 
 			logger.Info("Looking for extension", "process_name", o.ProcessName)
 
-			path, err := discovery.GetPathFromProcess(logger, o.ProcessName, o.ExtensionPath)
+			path, err := discovery.GetPathFromProcess(o.ProcessName, o.ExtensionPath)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Implements a logger interface in the collector package so the CLI application can render logs in the application.

```
// Logger for emitting collector events.
type Logger interface {
       Info(msg string, args ...any)
       Debug(msg string, args ...any)
       Error(msg string, args ...any)
}
```