### PR TITLE
Add slow-client timeouts to the sidecar HTTP server

### DIFF
--- a/cmd/compass-sidecar/main.go
+++ b/cmd/compass-sidecar/main.go
@@ -38,6 +38,22 @@ var cmdExample = `
 const HeaderToken = "X-Skpr-Token"
 
 var (
+	serverReadHeaderTimeout = 10 * time.Second
+	serverIdleTimeout       = 2 * time.Minute
+)
+
+func newServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:    addr,
+		Handler: handler,
+		// No WriteTimeout: /v1/traces streams for the life of the subscription,
+		// so slow clients are bounded by these two rather than a write deadline.
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+		IdleTimeout:       serverIdleTimeout,
+	}
+}
+
+var (
 	metricCollectorRunning = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "compass_sidecar_collector_running",
 		Help: "If the collector is running. 1 = on, 0 = off.",
@@ -178,10 +194,7 @@ func main() {
 					}
 				})
 
-				server := &http.Server{
-					Addr:    config.Addr,
-					Handler: mux,
-				}
+				server := newServer(config.Addr, mux)
 
 				// Start the server in its own goroutine.
 				eg.Go(func() error {

--- a/cmd/compass-sidecar/server_test.go
+++ b/cmd/compass-sidecar/server_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer_SetsSlowClientTimeouts(t *testing.T) {
+	server := newServer(":28624", http.NewServeMux())
+
+	assert.Equal(t, ":28624", server.Addr)
+	assert.Equal(t, serverReadHeaderTimeout, server.ReadHeaderTimeout)
+	assert.Equal(t, serverIdleTimeout, server.IdleTimeout)
+}
+
+func TestNewServer_DoesNotCapTheStream(t *testing.T) {
+	server := newServer(":28624", http.NewServeMux())
+
+	assert.Zero(t, server.WriteTimeout)
+}
+
+func TestNewServer_DisconnectsSlowHeaderClient(t *testing.T) {
+	prev := serverReadHeaderTimeout
+	serverReadHeaderTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { serverReadHeaderTimeout = prev })
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := newServer(listener.Addr().String(), http.NewServeMux())
+
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// A request line and one header, but no terminating blank line.
+	_, err = fmt.Fprint(conn, "GET /metrics HTTP/1.1\r\nHost: localhost\r\n")
+	require.NoError(t, err)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+
+	// The read completing (with EOF) rather than blocking is the property here.
+	_, err = io.ReadAll(conn)
+	assert.NoError(t, err, "server should close the connection, not leave it hanging")
+}
+
+func TestNewServer_ServesAfterHeaderTimeout(t *testing.T) {
+	prev := serverReadHeaderTimeout
+	serverReadHeaderTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { serverReadHeaderTimeout = prev })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ok", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ts := httptest.NewUnstartedServer(mux)
+	ts.Config = newServer("", mux)
+	ts.Start()
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/ok")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}


### PR DESCRIPTION
The sidecar built its http.Server with only Addr and Handler set, leaving every timeout at Go's unbounded default. A Slowloris-style client that dribbles request headers one byte at a time, or holds an idle keep-alive connection open, could pin a goroutine and file descriptor indefinitely and eventually exhaust the sidecar's descriptors.

Extract server construction into newServer and set ReadHeaderTimeout (the Slowloris defence) and IdleTimeout. WriteTimeout is left unset on purpose: the /v1/traces handler streams for the life of the subscription, so a write deadline would sever a healthy long-lived connection.

The timeouts are package variables, matching the backoff convention in pkg/app/tracer/http, so tests can shrink them. Adds tests covering the configured values, that WriteTimeout stays unset, that a slow-header client is disconnected once ReadHeaderTimeout fires, and a positive control that a complete request is still served.