### PR TITLE
Compare the sidecar token in constant time

### DIFF
--- a/cmd/compass-sidecar/auth_test.go
+++ b/cmd/compass-sidecar/auth_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthorized(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		got  string
+		ok   bool
+	}{
+		{name: "no token configured allows anything", want: "", got: "", ok: true},
+		{name: "no token configured ignores a presented one", want: "", got: "whatever", ok: true},
+		{name: "correct token", want: "s3cret", got: "s3cret", ok: true},
+		{name: "wrong token of the same length", want: "s3cret", got: "s3crat", ok: false},
+		{name: "wrong token of a different length", want: "s3cret", got: "s3", ok: false},
+		{name: "missing token when one is required", want: "s3cret", got: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.ok, authorized(tt.want, tt.got))
+		})
+	}
+}

--- a/cmd/compass-sidecar/main.go
+++ b/cmd/compass-sidecar/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +37,17 @@ var cmdExample = `
 
 // HeaderToken is the header this sidecar authenticates requests with.
 const HeaderToken = "X-Skpr-Token"
+
+// authorized reports whether a request may proceed. An empty configured token
+// disables authentication; otherwise the presented token must match in
+// constant time so a rejection does not leak how many leading bytes were right.
+func authorized(want, got string) bool {
+	if want == "" {
+		return true
+	}
+
+	return subtle.ConstantTimeCompare([]byte(want), []byte(got)) == 1
+}
 
 var (
 	serverReadHeaderTimeout = 10 * time.Second
@@ -141,7 +153,7 @@ func main() {
 				})
 
 				mux.HandleFunc("/v1/traces", func(w http.ResponseWriter, r *http.Request) {
-					if config.Token != "" && config.Token != r.Header.Get(HeaderToken) {
+					if !authorized(config.Token, r.Header.Get(HeaderToken)) {
 						w.WriteHeader(http.StatusUnauthorized)
 						fmt.Fprintln(w, "Access Denied")
 						return


### PR DESCRIPTION
The /v1/traces auth check compared the configured token against the presented one with !=, which short-circuits on the first differing byte. That leaks, through response timing, how many leading bytes a guess got right, letting an attacker recover the token one byte at a time.

Replace the comparison with crypto/subtle.ConstantTimeCompare behind an authorized helper, and add a test covering the empty-token, correct, wrong same-length, wrong different-length and missing cases.