### PR TITLE
Require the sidecar token on /metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ see [`docs/sidecar-config.yaml`](docs/sidecar-config.yaml).
 | `COMPASS_SIDECAR_NODE_ADDON_PATH` | `/usr/lib/compass/node/compass.node` | Addon path, inside the Node container. |
 | `COMPASS_SIDECAR_DISCOVERY_TIMEOUT` | `1m` | How long to wait for a runtime before deciding it is not present. |
 | `COMPASS_SIDECAR_MAX_FUNCTION_CALLS` | `10000` | Function calls retained per trace; later calls are counted as dropped. |
-| `COMPASS_SIDECAR_TOKEN` | | Require this token from clients. |
+| `COMPASS_SIDECAR_TOKEN` | | Require this token, as the `X-Skpr-Token` header, on both `/v1/traces` and `/metrics`. |
 | `COMPASS_SIDECAR_CERT_FILE` | | Serve traces over TLS with this certificate. |
 | `COMPASS_SIDECAR_KEY_FILE` | | Key for the TLS certificate. |
 

--- a/cmd/compass-sidecar/auth_test.go
+++ b/cmd/compass-sidecar/auth_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,38 @@ func TestAuthorized(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.ok, authorized(tt.want, tt.got))
+		})
+	}
+}
+
+func TestRequireToken(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name   string
+		token  string
+		header string
+		status int
+	}{
+		{name: "no token configured passes through", token: "", header: "", status: http.StatusOK},
+		{name: "correct token reaches the handler", token: "s3cret", header: "s3cret", status: http.StatusOK},
+		{name: "wrong token is rejected", token: "s3cret", header: "nope", status: http.StatusUnauthorized},
+		{name: "missing token is rejected", token: "s3cret", header: "", status: http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			if tt.header != "" {
+				req.Header.Set(HeaderToken, tt.header)
+			}
+
+			rec := httptest.NewRecorder()
+			requireToken(tt.token, next).ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.status, rec.Code)
 		})
 	}
 }

--- a/cmd/compass-sidecar/main.go
+++ b/cmd/compass-sidecar/main.go
@@ -49,6 +49,20 @@ func authorized(want, got string) bool {
 	return subtle.ConstantTimeCompare([]byte(want), []byte(got)) == 1
 }
 
+// requireToken gates a handler behind the configured token. An empty token
+// leaves the handler open.
+func requireToken(token string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !authorized(token, r.Header.Get(HeaderToken)) {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintln(w, "Access Denied")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
 var (
 	serverReadHeaderTimeout = 10 * time.Second
 	serverIdleTimeout       = 2 * time.Minute
@@ -148,17 +162,9 @@ func main() {
 			eg.Go(func() error {
 				mux := http.NewServeMux()
 
-				mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
-					promhttp.Handler().ServeHTTP(w, r)
-				})
+				mux.Handle("/metrics", requireToken(config.Token, promhttp.Handler()))
 
-				mux.HandleFunc("/v1/traces", func(w http.ResponseWriter, r *http.Request) {
-					if !authorized(config.Token, r.Header.Get(HeaderToken)) {
-						w.WriteHeader(http.StatusUnauthorized)
-						fmt.Fprintln(w, "Access Denied")
-						return
-					}
-
+				mux.Handle("/v1/traces", requireToken(config.Token, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					// Track the number of subscriptions for debugging how many clients are using the sidecar.
 					metricSubscription.Inc()
 					defer metricSubscription.Dec()
@@ -204,7 +210,7 @@ func main() {
 							flusher.Flush()
 						}
 					}
-				})
+				})))
 
 				server := newServer(config.Addr, mux)
 


### PR DESCRIPTION
Only /v1/traces checked COMPASS_SIDECAR_TOKEN; /metrics was served to anyone who could reach the port. Those metrics disclose deployment topology (which runtimes were discovered), whether observers are attached, and internal saturation levels, so a deployment that sets a token reasonably expects it to gate the whole sidecar.

Introduce a requireToken middleware built on the existing authorized helper and apply it to both routes, so there is a single auth path. Document in the README that the token guards both /v1/traces and /metrics, and add middleware tests covering the pass-through, correct, wrong and missing cases.