### PR TITLE
Label the trace stream as NDJSON, not SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ extension predating them keeps its PHP tracing and loses only the Drupal page.
 
 | Flag | Environment variable | Default | Description |
 | --- | --- | --- | --- |
-| `--uri` | `COMPASS_URI` | `http://localhost:28624/v1/traces` | Trace stream to connect to. `extension:///path/to/compass.so` traces a probe file directly. |
+| `--uri` | `COMPASS_URI` | `http://localhost:28624/v1/traces` | Trace stream to connect to, served as newline-delimited JSON (`application/x-ndjson`). `extension:///path/to/compass.so` traces a probe file directly. |
 | `--token` | `COMPASS_TOKEN` | | Sent to the sidecar as the `X-Skpr-Token` header. |
 | `--ca-file` | `COMPASS_CA_FILE` | | Certificate authority which signed the sidecar certificate. |
 | `--insecure-skip-verify` | `COMPASS_INSECURE_SKIP_VERIFY` | `false` | Skip verification of the sidecar certificate. |

--- a/cmd/compass-sidecar/main.go
+++ b/cmd/compass-sidecar/main.go
@@ -179,7 +179,10 @@ func main() {
 					subscriber := b.Subscribe()
 					defer b.Unsubscribe(subscriber)
 
-					w.Header().Set("Content-Type", "text/event-stream")
+					// The stream is newline-delimited JSON: one trace object per
+					// line, as json.NewEncoder writes below. It is not SSE, so it
+					// is labelled as NDJSON rather than text/event-stream.
+					w.Header().Set("Content-Type", "application/x-ndjson")
 					w.Header().Set("Cache-Control", "no-cache")
 					w.Header().Set("Connection", "keep-alive")
 					w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
The /v1/traces handler advertised Content-Type text/event-stream but wrote newline-delimited JSON: json.NewEncoder emits one object per line, not the 'data:'-prefixed, blank-line-separated frames SSE requires. A conformant SSE client reads the whole response as one unterminated event. The Compass CLI works only because it parses the body as line-delimited JSON and never checks the content type.

Relabel the response as application/x-ndjson, which matches the bytes on the wire; no wire change is needed and the CLI is unaffected. Document the format on the --uri row in the README.